### PR TITLE
Import node modules via protocol imports so this library can be used on edge

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
-const { strict: assert } = require('assert');
-const { createHash } = require('crypto');
-const { format } = require('util');
+const { strict: assert } = require('node:assert');
+const { createHash } = require('node:crypto');
+const { format } = require('node:util');
 
 const shake256 = require('./shake256');
 

--- a/lib/shake256.js
+++ b/lib/shake256.js
@@ -1,4 +1,4 @@
-const crypto = require('crypto');
+const crypto = require('node:crypto');
 
 const [major, minor] = process.version.substring(1).split('.').map((x) => parseInt(x, 10));
 const xofOutputLength = major > 12 || (major === 12 && minor >= 8);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-token-hash",
-  "version": "5.0.3",
+  "version": "6.0.3",
   "homepage": "https://github.com/panva/oidc-token-hash",
   "bugs": {
     "url": "https://github.com/panva/oidc-token-hash/issues"
@@ -25,7 +25,7 @@
     "nyc": "^15.1.0"
   },
   "engines": {
-    "node": "^10.13.0 || >=12.0.0"
+    "node": ">=12.20.0"
   },
   "nyc": {
     "reporter": [


### PR DESCRIPTION
I tried to use this library on Cloudflare, but found it wasn't possible since it uses the "classic" import for node built-ins. This changes it to the newer protocol import style, which is what some edge providers(Cloudflare) expect.

https://dev.to/yenyih/new-nodejs-protocol-imports-3pnf

I did bump the major version since this would cause node js <12.20 client to be unable to use this library any longer.