### PR TITLE
Throw an error if outside Node.js

### DIFF
--- a/lib/shake256.js
+++ b/lib/shake256.js
@@ -1,8 +1,13 @@
 const crypto = require('crypto');
-if(!process || process.version === undefined) {
-  throw new TypeError("This library cannot be used outside of Node.js.");
+
+if (!process || typeof process.version === 'undefined') {
+  throw new TypeError('Unsupported runtime, please use Node.js');
 }
-const [major, minor] = process.version.substring(1).split('.').map((x) => parseInt(x, 10));
+
+const [major, minor] = process.version
+  .substring(1)
+  .split('.')
+  .map((x) => parseInt(x, 10));
 const xofOutputLength = major > 12 || (major === 12 && minor >= 8);
 const shake256 = xofOutputLength && crypto.getHashes().includes('shake256');
 

--- a/lib/shake256.js
+++ b/lib/shake256.js
@@ -1,5 +1,7 @@
 const crypto = require('crypto');
-
+if(!process || process.version === undefined) {
+  throw new TypeError("This library cannot be used outside of Node.js.");
+}
 const [major, minor] = process.version.substring(1).split('.').map((x) => parseInt(x, 10));
 const xofOutputLength = major > 12 || (major === 12 && minor >= 8);
 const shake256 = xofOutputLength && crypto.getHashes().includes('shake256');


### PR DESCRIPTION
As per title, throw a nicer error if the library is used outside of node.js. I am trying to migrate next-auth from v4 to v5, and in the meantime an error was thrown by this library because of it running outside of node.js:

```
⨯ Error [TypeError]: Cannot read properties of undefined (reading 'substring')
    at <unknown> (webpack-internal:///(middleware)/./node_modules/oidc-token-hash/lib/shake256.js:3)
    at eval (webpack-internal:///(middleware)/./node_modules/oidc-token-hash/lib/shake256.js:3:40)
    at (middleware)/./node_modules/oidc-token-hash/lib/shake256.js (file://{cwd}\.next\server\src\middleware.js:1271:1)
    at __webpack_require__ (file://{cwd}\.next\server\edge-runtime-webpack.js:37:33)
   { redacted for readability }
```

I think it would be nicer if it instead had an error message stating what the problem is, like so:

```
⨯ Error [TypeError]: Unsupported runtime, please use Node.js
    at <unknown> (webpack-internal:///(middleware)/./node_modules/oidc-token-hash/lib/shake256.js:4)
    at eval (webpack-internal:///(middleware)/./node_modules/oidc-token-hash/lib/shake256.js:4:11)
    at (middleware)/./node_modules/oidc-token-hash/lib/shake256.js 
    { redacted for readability }
```